### PR TITLE
Fix 'style' metadata parsing to ignore spaces between items.

### DIFF
--- a/src/components/Group.ts
+++ b/src/components/Group.ts
@@ -32,14 +32,14 @@ export default class Group extends AbstractComponent<FaustUIGroupProps> {
         if (!metaIn) return { metaObject };
         metaIn.forEach(m => Object.assign(metaObject, m));
         if (metaObject.style) {
-            const enumsRegex = /\{(?:(?:'|_|-)(.+?)(?:'|_|-):([-+]?[0-9]*\.?[0-9]+);)+(?:(?:'|_|-)(.+?)(?:'|_|-):([-+]?[0-9]*\.?[0-9]+))\}/;
+            const enumsRegex = /\{\s*(?:['_\-](.+?)['_\-]\s*:\s*([-+]?[0-9]*\.?[0-9]+)\s*;\s*)+(?:['_\-](.+?)['_\-]\s*:\s*([-+]?[0-9]*\.?[0-9]+))\s*\}/;
             const matched = metaObject.style.match(enumsRegex);
             if (matched) {
-                const itemsRegex = /(?:(?:'|_|-)(.+?)(?:'|_|-):([-+]?[0-9]*\.?[0-9]+))/g;
+                const itemsRegex = /['_\-](.+?)['_\-]\s*:\s*([-+]?[0-9]*\.?[0-9]+)\s*/g;
                 const enums: { [key: string]: number } = {};
                 let item;
                 // eslint-disable-next-line no-cond-assign
-                while (item = itemsRegex.exec(matched[0])) {
+                while ((item = itemsRegex.exec(matched[0]))) {
                     enums[item[1]] = +item[2];
                 }
                 return { metaObject, enums };


### PR DESCRIPTION
@Fr0stbyteR this ChatGPT generated fix is for this bug:

The following DSP is not properly displayed because of the spaces between items:
`process = hslider("BinOp Sel0[style:menu{'AND':0;  'OR':1; 'XOR':2;  'Bypass':3; 'Off':4}]", 0, 0, 4, 1);`
Where this was working: `process = hslider("BinOp Sel0[style:menu{'AND':0;'OR':1; 'XOR':2;'Bypass':3; 'Off':4}]", 0, 0, 4, 1);`
Same issue with radio style. 

Not sure this the the best way, thanks for considering. 